### PR TITLE
DOC-183. Fixing non-recursing delete on filesystem, public key removal

### DIFF
--- a/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/BaseE2ETest.java
+++ b/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/BaseE2ETest.java
@@ -247,9 +247,6 @@ public abstract class BaseE2ETest extends BaseMockitoTest {
                     .extracting(URI::toString)
                     .containsExactlyInAnyOrder(
                             "",
-                            "john/",
-                            "john/public/",
-                            "john/private/",
                             "profiles/",
                             "profiles/public/",
                             "profiles/private/"

--- a/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/BaseE2ETest.java
+++ b/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/BaseE2ETest.java
@@ -18,11 +18,13 @@ import de.adorsys.datasafe.privatestore.api.actions.ListPrivate;
 import de.adorsys.datasafe.privatestore.api.actions.ReadFromPrivate;
 import de.adorsys.datasafe.privatestore.api.actions.RemoveFromPrivate;
 import de.adorsys.datasafe.privatestore.api.actions.WriteToPrivate;
+import de.adorsys.datasafe.storage.impl.fs.FileSystemStorageService;
 import de.adorsys.datasafe.types.api.actions.ListRequest;
 import de.adorsys.datasafe.types.api.actions.ReadRequest;
 import de.adorsys.datasafe.types.api.actions.RemoveRequest;
 import de.adorsys.datasafe.types.api.actions.WriteRequest;
 import de.adorsys.datasafe.types.api.resource.AbsoluteLocation;
+import de.adorsys.datasafe.types.api.resource.BasePrivateResource;
 import de.adorsys.datasafe.types.api.resource.PrivateResource;
 import de.adorsys.datasafe.types.api.resource.ResolvedResource;
 import de.adorsys.datasafe.types.api.shared.BaseMockitoTest;
@@ -34,6 +36,10 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -220,6 +226,34 @@ public abstract class BaseE2ETest extends BaseMockitoTest {
 
         for (String toFind : expected) {
             assertThat(paths.stream().anyMatch(it -> it.equals(toFind))).isTrue();
+        }
+    }
+
+    @SneakyThrows
+    protected void assertRootDirIsEmpty(WithStorageProvider.StorageDescriptor descriptor) {
+        assertThat(descriptor.getStorageService().get()
+                .list(
+                        new AbsoluteLocation<>(BasePrivateResource.forPrivate(descriptor.getLocation()))
+                )
+        ).isEmpty();
+        if (descriptor.getStorageService().get() instanceof FileSystemStorageService) {
+            // additional check that directory contains only folders that were created recursively
+            // we do not have permission to delete these - because we removed files linked to profile
+            // however we can't remove anything above
+            assertThat(Files.walk(Paths.get(descriptor.getLocation().asURI())))
+                    .allMatch(it -> it.toFile().isDirectory())
+                    .extracting(Path::toUri)
+                    .extracting(it -> descriptor.getLocation().asURI().relativize(it))
+                    .extracting(URI::toString)
+                    .containsExactlyInAnyOrder(
+                            "",
+                            "john/",
+                            "john/public/",
+                            "john/private/",
+                            "profiles/",
+                            "profiles/public/",
+                            "profiles/private/"
+                    );
         }
     }
 }

--- a/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/BasicFunctionalityTest.java
+++ b/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/BasicFunctionalityTest.java
@@ -46,6 +46,24 @@ class BasicFunctionalityTest extends WithStorageProvider {
         assertThat(profileRetrievalService.userExists(userJohn)).isFalse();
     }
 
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("allStorages")
+    void testUserIsRemovedWithFiles(WithStorageProvider.StorageDescriptor descriptor) {
+        init(descriptor);
+        UserID userJohn = new UserID("john");
+        john = registerUser(userJohn.getValue());
+        writeDataToPrivate(john, "root.txt", MESSAGE_ONE);
+        writeDataToPrivate(john, "some/some.txt", MESSAGE_ONE);
+        writeDataToPrivate(john, "some/another_one.txt", MESSAGE_ONE);
+        writeDataToPrivate(john, "some/other/other.txt", MESSAGE_ONE);
+        writeDataToPrivate(john, "different/data.txt", MESSAGE_ONE);
+
+        profileRemovalService.deregister(john);
+
+        assertRootDirIsEmpty(descriptor);
+    }
+
     @ParameterizedTest
     @MethodSource("allStorages")
     void testWriteToPrivateListPrivateReadPrivateAndSendToAndReadFromInbox(

--- a/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/VersionedDataTest.java
+++ b/datasafe-business/src/test/java/de/adorsys/datasafe/business/impl/e2e/VersionedDataTest.java
@@ -2,6 +2,7 @@ package de.adorsys.datasafe.business.impl.e2e;
 
 import com.google.common.io.ByteStreams;
 import de.adorsys.datasafe.business.impl.service.VersionedDatasafeServices;
+import de.adorsys.datasafe.encrypiton.api.types.UserID;
 import de.adorsys.datasafe.encrypiton.api.types.UserIDAuth;
 import de.adorsys.datasafe.metainfo.version.impl.version.types.DFSVersion;
 import de.adorsys.datasafe.types.api.actions.ListRequest;
@@ -51,6 +52,22 @@ public class VersionedDataTest extends WithStorageProvider {
 
         assertThat(readingResult).isEqualTo(MESSAGE_THREE);
         validateThereAreVersions(jane, 3);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("allStorages")
+    void testUserIsRemovedWithFiles(WithStorageProvider.StorageDescriptor descriptor) {
+        init(descriptor);
+        UserID userJohn = new UserID("john");
+        john = registerUser(userJohn.getValue());
+        writeDataToPrivate(john, "root.txt", MESSAGE_ONE);
+        writeDataToPrivate(john, "some/some.txt", MESSAGE_ONE);
+        writeDataToPrivate(john, "some/other/other.txt", MESSAGE_ONE);
+
+        profileRemovalService.deregister(john);
+
+        assertRootDirIsEmpty(descriptor);
     }
 
     @ParameterizedTest

--- a/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/profile/dfs/BucketAccessService.java
+++ b/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/profile/dfs/BucketAccessService.java
@@ -11,6 +11,9 @@ import de.adorsys.datasafe.types.api.resource.PublicResource;
  * Runs just before accessing underlying filesystem.
  * May perform additional resource resolution and enriches resource location with credentials necessary
  * to access underlying filesystem.
+ * For example it can act as gateway transforming dfs://user/path into s3://user-1-bucket/root/path
+ * Or it can add credentials transforming:
+ * s3://user-1-bucket/root/path into s3://username:password@user-1-bucket/root/path
  */
 public interface BucketAccessService {
 
@@ -29,4 +32,13 @@ public interface BucketAccessService {
      * @return Physical resource location with credentials required to access it.
      */
     AbsoluteLocation<PublicResource> publicAccessFor(UserID user, PublicResource resource);
+
+    /**
+     * Gets credentials to access specified private resource as a system and may perform additional path resolution.
+     * This is mostly for storing user metadata like his profile.
+     * <b>Note</b> that system <b>should not</b> have access to real user private/public resource.
+     * @param resource System-internal resource (private, either relative or absolute)
+     * @return Physical resource location with credentials required to access it.
+     */
+    AbsoluteLocation withSystemAccess(AbsoluteLocation resource);
 }

--- a/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/CreateUserPrivateProfile.java
+++ b/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/CreateUserPrivateProfile.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
+import java.util.List;
+
 /**
  * Request to create private user profile part.
  */
@@ -45,6 +47,13 @@ public class CreateUserPrivateProfile {
     private final AbsoluteLocation<PrivateResource> documentVersionStorage;
 
     /**
+     * If all files reside within some specific folder, one can simply remove it when deregistering user,
+     * instead of removing files one-by-one - this is the list of such folders.
+     */
+    @NonNull
+    private final List<AbsoluteLocation<PrivateResource>> associatedResources;
+
+    /**
      * Where to publish users' public keys if it is necessary.
      */
     private final AbsoluteLocation<PublicResource> publishPubKeysTo;
@@ -56,6 +65,7 @@ public class CreateUserPrivateProfile {
             .privateStorage(privateStorage)
             .inboxWithFullAccess(inboxWithWriteAccess)
             .documentVersionStorage(documentVersionStorage)
+            .associatedResources(associatedResources)
             .build();
     }
 }

--- a/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/CreateUserPrivateProfile.java
+++ b/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/CreateUserPrivateProfile.java
@@ -48,7 +48,8 @@ public class CreateUserPrivateProfile {
 
     /**
      * If all files reside within some specific folder, one can simply remove it when deregistering user,
-     * instead of removing files one-by-one - this is the list of such folders.
+     * instead of removing files one-by-one - this is the list of such folders, or if we need to remove extra
+     * associated resources with user.
      */
     @NonNull
     private final List<AbsoluteLocation<PrivateResource>> associatedResources;

--- a/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/UserPrivateProfile.java
+++ b/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/UserPrivateProfile.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 
+import java.util.List;
+
 /**
  * Users' private profile - typically should be seen only by owner.
  */
@@ -35,4 +37,11 @@ public class UserPrivateProfile {
      * Where to store users' links to latest documents if software versioning is enabled.
      */
     private final AbsoluteLocation<PrivateResource> documentVersionStorage;
+
+    /**
+     * If all files reside within some specific folder, one can simply remove it when deregistering user,
+     * instead of removing files one-by-one - this is the list of such folders.
+     */
+    @NonNull
+    private final List<AbsoluteLocation<PrivateResource>> associatedResources;
 }

--- a/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/UserPrivateProfile.java
+++ b/datasafe-directory/datasafe-directory-api/src/main/java/de/adorsys/datasafe/directory/api/types/UserPrivateProfile.java
@@ -40,7 +40,8 @@ public class UserPrivateProfile {
 
     /**
      * If all files reside within some specific folder, one can simply remove it when deregistering user,
-     * instead of removing files one-by-one - this is the list of such folders.
+     * instead of removing files one-by-one - this is the list of such folders, or if we need to remove extra
+     * associated resources with user.
      */
     @NonNull
     private final List<AbsoluteLocation<PrivateResource>> associatedResources;

--- a/datasafe-directory/datasafe-directory-impl/src/main/java/de/adorsys/datasafe/directory/impl/profile/config/DefaultDFSConfig.java
+++ b/datasafe-directory/datasafe-directory-impl/src/main/java/de/adorsys/datasafe/directory/impl/profile/config/DefaultDFSConfig.java
@@ -11,6 +11,7 @@ import de.adorsys.datasafe.types.api.resource.*;
 import lombok.RequiredArgsConstructor;
 
 import java.net.URI;
+import java.util.Collections;
 
 /**
  * Default DFS folders layout provider, suitable both for s3 and filesystem.
@@ -92,6 +93,7 @@ public class DefaultDFSConfig implements DFSConfig {
                 .inboxWithWriteAccess(accessPrivate(inbox(rootLocation)))
                 .documentVersionStorage(accessPrivate(rootLocation.resolve("./" + VERSION_COMPONENT + "/")))
                 .publishPubKeysTo(access(publicKeys(rootLocation)))
+                .associatedResources(Collections.singletonList(accessPrivate(rootLocation)))
                 .build();
     }
 

--- a/datasafe-directory/datasafe-directory-impl/src/main/java/de/adorsys/datasafe/directory/impl/profile/dfs/BucketAccessServiceImpl.java
+++ b/datasafe-directory/datasafe-directory-impl/src/main/java/de/adorsys/datasafe/directory/impl/profile/dfs/BucketAccessServiceImpl.java
@@ -12,8 +12,12 @@ import lombok.extern.slf4j.Slf4j;
 import javax.inject.Inject;
 
 /**
- * Specifies how to access desired user resource (example: private bucket). By default is no-op - simply wraps
- * resource into {@link AbsoluteLocation}
+ * Specifies how to access desired user resource (example: private bucket).
+ * It can be used for:
+ * 1. To add user-specific credentials, if it is 1 user per bucket or similar
+ * 2. To redirect requests
+ *
+ * By default is no-op - simply wraps resource into {@link AbsoluteLocation}
  */
 @Slf4j
 @RuntimeDelegate
@@ -38,6 +42,15 @@ public class BucketAccessServiceImpl implements BucketAccessService {
     @Override
     public AbsoluteLocation<PublicResource> publicAccessFor(UserID user, PublicResource resource) {
         log.debug("get public access for user {} and bucket {}", user, resource.location());
+        return new AbsoluteLocation<>(resource);
+    }
+
+    /**
+     * Do nothing, just wrap, real use case would be to plug user credentials to access bucket.
+     */
+    @Override
+    public AbsoluteLocation withSystemAccess(AbsoluteLocation resource) {
+        log.debug("get syste access for {}", resource.location());
         return new AbsoluteLocation<>(resource);
     }
 }

--- a/datasafe-directory/datasafe-directory-impl/src/main/java/de/adorsys/datasafe/directory/impl/profile/operations/actions/ProfileRegistrationServiceImpl.java
+++ b/datasafe-directory/datasafe-directory-impl/src/main/java/de/adorsys/datasafe/directory/impl/profile/operations/actions/ProfileRegistrationServiceImpl.java
@@ -1,6 +1,7 @@
 package de.adorsys.datasafe.directory.impl.profile.operations.actions;
 
 import de.adorsys.datasafe.directory.api.config.DFSConfig;
+import de.adorsys.datasafe.directory.api.profile.dfs.BucketAccessService;
 import de.adorsys.datasafe.directory.api.profile.operations.ProfileRegistrationService;
 import de.adorsys.datasafe.directory.api.types.CreateUserPrivateProfile;
 import de.adorsys.datasafe.directory.api.types.CreateUserPublicProfile;
@@ -28,15 +29,18 @@ import java.util.List;
 public class ProfileRegistrationServiceImpl implements ProfileRegistrationService {
 
     private final KeyStoreService keyStoreService;
+    private final BucketAccessService access;
     private final StorageCheckService checkService;
     private final StorageWriteService writeService;
     private final GsonSerde serde;
     private final DFSConfig dfsConfig;
 
     @Inject
-    public ProfileRegistrationServiceImpl(KeyStoreService keyStoreService, StorageCheckService checkService,
-                                          StorageWriteService writeService, GsonSerde serde, DFSConfig dfsConfig) {
+    ProfileRegistrationServiceImpl(KeyStoreService keyStoreService, BucketAccessService access,
+                                          StorageCheckService checkService, StorageWriteService writeService,
+                                          GsonSerde serde, DFSConfig dfsConfig) {
         this.keyStoreService = keyStoreService;
+        this.access = access;
         this.checkService = checkService;
         this.writeService = writeService;
         this.serde = serde;
@@ -52,7 +56,7 @@ public class ProfileRegistrationServiceImpl implements ProfileRegistrationServic
     @SneakyThrows
     public void registerPublic(CreateUserPublicProfile profile) {
         log.debug("Register public {}", profile);
-        try (OutputStream os = writeService.write(dfsConfig.publicProfile(profile.getId()))) {
+        try (OutputStream os = writeService.write(access.withSystemAccess(dfsConfig.publicProfile(profile.getId())))) {
             os.write(serde.toJson(profile.removeAccess()).getBytes());
         }
     }
@@ -67,11 +71,13 @@ public class ProfileRegistrationServiceImpl implements ProfileRegistrationServic
     @SneakyThrows
     public void registerPrivate(CreateUserPrivateProfile profile) {
         log.debug("Register private {}", profile);
-        try (OutputStream os = writeService.write(dfsConfig.privateProfile(profile.getId().getUserID()))) {
+        try (OutputStream os = writeService.write(
+                access.withSystemAccess(dfsConfig.privateProfile(profile.getId().getUserID())))
+        ) {
             os.write(serde.toJson(profile.removeAccess()).getBytes());
         }
 
-        if (checkService.objectExists(profile.getKeystore())) {
+        if (checkService.objectExists(access.withSystemAccess(profile.getKeystore()))) {
             log.warn("Keystore already exists for {} at {}, will not create new",
                     profile.getId().getUserID(), Log.secure(profile.getKeystore()));
             return;
@@ -106,7 +112,7 @@ public class ProfileRegistrationServiceImpl implements ProfileRegistrationServic
                 new KeyStoreCreationConfig(1, 1)
         );
 
-        try (OutputStream os = writeService.write(keystore)) {
+        try (OutputStream os = writeService.write(access.withSystemAccess(keystore))) {
             os.write(keyStoreService.serialize(keystoreBlob, forUser.getValue(), auth.getReadStorePassword()));
         }
         log.debug("Keystore created for user {} in path {}", forUser, keystore);
@@ -118,8 +124,8 @@ public class ProfileRegistrationServiceImpl implements ProfileRegistrationServic
     private void publishPublicKeysIfNeeded(AbsoluteLocation publishTo,
                                            List<PublicKeyIDWithPublicKey> publicKeys) {
 
-        if (null != publishTo && !checkService.objectExists(publishTo)) {
-            try (OutputStream os = writeService.write(publishTo)) {
+        if (null != publishTo && !checkService.objectExists(access.withSystemAccess(publishTo))) {
+            try (OutputStream os = writeService.write(access.withSystemAccess(publishTo))) {
                 os.write(serde.toJson(publicKeys).getBytes());
             }
             log.debug("Public keys for published {}", publishTo);

--- a/datasafe-directory/datasafe-directory-impl/src/test/java/de/adorsys/datasafe/directory/impl/profile/keys/DFSPrivateKeyServiceImplTest.java
+++ b/datasafe-directory/datasafe-directory-impl/src/test/java/de/adorsys/datasafe/directory/impl/profile/keys/DFSPrivateKeyServiceImplTest.java
@@ -15,6 +15,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 
 import java.security.KeyStore;
+import java.util.Collections;
 import java.util.HashMap;
 
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ class DFSPrivateKeyServiceImplTest extends BaseMockitoTest {
             .inboxWithFullAccess(PRIVATE)
             .keystore(PRIVATE)
             .documentVersionStorage(PRIVATE)
+            .associatedResources(Collections.emptyList())
             .build();
 
     private UserPublicProfile publicProfile = UserPublicProfile.builder()

--- a/datasafe-storage/datasafe-storage-impl-fs/src/main/java/de/adorsys/datasafe/storage/impl/fs/FileSystemStorageService.java
+++ b/datasafe-storage/datasafe-storage-impl-fs/src/main/java/de/adorsys/datasafe/storage/impl/fs/FileSystemStorageService.java
@@ -1,6 +1,7 @@
 package de.adorsys.datasafe.storage.impl.fs;
 
 import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 import de.adorsys.datasafe.storage.api.StorageService;
 import de.adorsys.datasafe.types.api.resource.*;
 import de.adorsys.datasafe.types.api.utils.Log;
@@ -85,7 +86,7 @@ public class FileSystemStorageService implements StorageService {
 
         Path path = resolve(location.location().asURI(), false);
         boolean isFile = !path.toFile().isDirectory();
-        Files.delete(resolve(location.location().asURI(), false));
+        MoreFiles.deleteRecursively(path, RecursiveDeleteOption.ALLOW_INSECURE);
         log.debug("deleted {} at: {}", isFile ? "file" : "directory", Log.secure(location));
     }
 

--- a/datasafe-storage/datasafe-storage-impl-fs/src/test/java/de/adorsys/datasafe/storage/impl/fs/FileSystemStorageServiceTest.java
+++ b/datasafe-storage/datasafe-storage-impl-fs/src/test/java/de/adorsys/datasafe/storage/impl/fs/FileSystemStorageServiceTest.java
@@ -5,7 +5,6 @@ import de.adorsys.datasafe.types.api.resource.BasePrivateResource;
 import de.adorsys.datasafe.types.api.resource.PrivateResource;
 import de.adorsys.datasafe.types.api.resource.Uri;
 import de.adorsys.datasafe.types.api.shared.BaseMockitoTest;
-import de.adorsys.datasafe.types.api.utils.Log;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
@@ -17,15 +16,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Slf4j
 class FileSystemStorageServiceTest extends BaseMockitoTest {
@@ -147,6 +144,18 @@ class FileSystemStorageServiceTest extends BaseMockitoTest {
         }
 
         assertThat(storageService.read(fileWithMsg)).hasContent(MESSAGE);
+    }
+
+    @Test
+    @SneakyThrows
+    void removeRemovesOnlyFile() {
+        createFileWithMessage("in/some.txt", true);
+        createFileWithMessage("in/some_other.txt", false);
+
+        storageService.remove(BasePrivateResource.forAbsolutePrivate(storageDir.toUri().resolve("in/some_other.txt")));
+
+        assertThat(Files.walk(storageDir.resolve("in/some.txt"))).hasSize(1);
+        assertThrows(NoSuchFileException.class, () -> Files.walk(storageDir.resolve("in/some_other.txt")));
     }
 
     @Test


### PR DESCRIPTION
Fixed stuff with not removed directories and public keys.
BUT, still to remove everything including created directories (solely on filesystem) special configuration is needed, because user profile points to file. For example one can push all user information in some user specific folder and then remove it (by extending ProfileRemovalServiceImpl using OverrideRegistry or by setting proper associatedResources)
