### PR TITLE
Feature/doc 188

### DIFF
--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/pom.xml
@@ -22,6 +22,13 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-simple.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.4.1</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentDirectoryFQN.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentDirectoryFQN.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
-@Getter
 @ToString
 public class DocumentDirectoryFQN {
     private String value;
@@ -13,12 +12,20 @@ public class DocumentDirectoryFQN {
         if (s == null) {
             throw new SimpleAdapterException("DocumentDirectoryFQN must not be null");
         }
+
+        // remove trailing slash
         s = s.replaceAll("//+","/");
         if (s.substring(s.length() - 1).equals("/")) {
             value = s.substring(0,s.length()-1);
         } else {
             value = s;
         }
+
+        // add leading slash
+        if (!value.substring(0,1).equals("/")) {
+            value = "/" + value;
+        }
+
     }
     public DocumentDirectoryFQN addDirectory(String s) {
         return new DocumentDirectoryFQN(value + "/" + s);
@@ -27,4 +34,15 @@ public class DocumentDirectoryFQN {
     public DocumentFQN addName(String s) {
         return new DocumentFQN(value + "/" + s);
     }
+
+    // docusafe path always with a slash in the beginning
+    public String getDocusafePath() {
+        return value;
+    }
+
+    // datasave path never with a slash in the beginning
+    public String getDatasafePath() {
+        return value.substring(1);
+    }
+
 }

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentDirectoryFQN.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentDirectoryFQN.java
@@ -1,8 +1,6 @@
 package de.adorsys.datasafe.simple.adapter.api.types;
 
 import de.adorsys.datasafe.simple.adapter.api.exceptions.SimpleAdapterException;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.ToString;
 
 @ToString
@@ -11,6 +9,10 @@ public class DocumentDirectoryFQN {
     public DocumentDirectoryFQN(String s) {
         if (s == null) {
             throw new SimpleAdapterException("DocumentDirectoryFQN must not be null");
+        }
+        if (s.length() == 0) {
+            location = "/";
+            return;
         }
 
         String value = null;

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentDirectoryFQN.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentDirectoryFQN.java
@@ -7,11 +7,13 @@ import lombok.ToString;
 
 @ToString
 public class DocumentDirectoryFQN {
-    private String value;
+    private final String location;
     public DocumentDirectoryFQN(String s) {
         if (s == null) {
             throw new SimpleAdapterException("DocumentDirectoryFQN must not be null");
         }
+
+        String value = null;
 
         // remove trailing slash
         s = s.replaceAll("//+","/");
@@ -25,24 +27,25 @@ public class DocumentDirectoryFQN {
         if (!value.substring(0,1).equals("/")) {
             value = "/" + value;
         }
+        location = value;
 
-    }
+        }
     public DocumentDirectoryFQN addDirectory(String s) {
-        return new DocumentDirectoryFQN(value + "/" + s);
+        return new DocumentDirectoryFQN(location + "/" + s);
     }
 
     public DocumentFQN addName(String s) {
-        return new DocumentFQN(value + "/" + s);
+        return new DocumentFQN(location + "/" + s);
     }
 
     // docusafe path always with a slash in the beginning
     public String getDocusafePath() {
-        return value;
+        return location;
     }
 
     // datasave path never with a slash in the beginning
     public String getDatasafePath() {
-        return value.substring(1);
+        return location.substring(1);
     }
 
 }

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentFQN.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentFQN.java
@@ -1,10 +1,7 @@
 package de.adorsys.datasafe.simple.adapter.api.types;
 
 import de.adorsys.datasafe.simple.adapter.api.exceptions.SimpleAdapterException;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
 
 @EqualsAndHashCode
 public class DocumentFQN {
@@ -15,7 +12,13 @@ public class DocumentFQN {
             throw new SimpleAdapterException("DocumentFQN must not be null");
         }
 
+        if (s.length() == 0) {
+            location = "/";
+            return;
+        }
+
         String value = null;
+
 
         // remove trailing slash
         s = s.replaceAll("//+", "/");

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentFQN.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentFQN.java
@@ -6,8 +6,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-@Getter
-@ToString
 @EqualsAndHashCode
 public class DocumentFQN {
     private String value;
@@ -17,6 +15,7 @@ public class DocumentFQN {
             throw new SimpleAdapterException("DocumentFQN must not be null");
         }
 
+        // remove trailing slash
         s = s.replaceAll("//+", "/");
         if (s.substring(s.length() - 1).equals("/")) {
             value = s.substring(0, s.length() - 1);
@@ -24,5 +23,19 @@ public class DocumentFQN {
             value = s;
         }
 
+        // add leading slash
+        if (!value.substring(0,1).equals("/")) {
+            value = "/" + value;
+        }
+    }
+
+    // docusafe path always with a slash in the beginning
+    public String getDocusafePath() {
+        return value;
+    }
+
+    // datasave path never with a slash in the beginning
+    public String getDatasafePath() {
+        return value.substring(1);
     }
 }

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentFQN.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/main/java/de/adorsys/datasafe/simple/adapter/api/types/DocumentFQN.java
@@ -8,12 +8,14 @@ import lombok.ToString;
 
 @EqualsAndHashCode
 public class DocumentFQN {
-    private String value;
+    private final String location;
 
     public DocumentFQN(String s) {
         if (s == null) {
             throw new SimpleAdapterException("DocumentFQN must not be null");
         }
+
+        String value = null;
 
         // remove trailing slash
         s = s.replaceAll("//+", "/");
@@ -27,15 +29,17 @@ public class DocumentFQN {
         if (!value.substring(0,1).equals("/")) {
             value = "/" + value;
         }
+
+        location = value;
     }
 
     // docusafe path always with a slash in the beginning
     public String getDocusafePath() {
-        return value;
+        return location;
     }
 
     // datasave path never with a slash in the beginning
     public String getDatasafePath() {
-        return value.substring(1);
+        return location.substring(1);
     }
 }

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/test/java/de/adorsys/datasafe/simple/adapter/api/DocumentDirectoryFQNTest.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/test/java/de/adorsys/datasafe/simple/adapter/api/DocumentDirectoryFQNTest.java
@@ -1,4 +1,4 @@
-package de.adorsys.datasafe.simple.adapter.impl;
+package de.adorsys.datasafe.simple.adapter.api;
 
 
 import de.adorsys.datasafe.simple.adapter.api.types.DocumentDirectoryFQN;
@@ -17,25 +17,14 @@ public class DocumentDirectoryFQNTest {
         Assertions.assertEquals("/a/b/c", d.getDocusafePath());
     }
     @Test
-    public void slashesForFiles() {
-        DocumentFQN d = new DocumentFQN("/a/b/c");
-        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
-        d = new DocumentFQN("/a/b/c/");
-        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
-        d = new DocumentFQN("/a///b//c/");
-        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
-    }
-
-    @Test
-    public void startingSlashForDocumentFQN() {
-        DocumentFQN d = new DocumentFQN("/a/b/c");
-        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
-        Assertions.assertEquals("a/b/c", d.getDatasafePath());
-    }
-    @Test
     public void startingSlashForDocumentDirectoryFQN() {
         DocumentDirectoryFQN d = new DocumentDirectoryFQN("/a/b/c");
         Assertions.assertEquals("/a/b/c", d.getDocusafePath());
         Assertions.assertEquals("a/b/c", d.getDatasafePath());
+    }
+    @Test void emptyDocumentDirectoryFQN() {
+        DocumentDirectoryFQN d = new DocumentDirectoryFQN("");
+        Assertions.assertEquals("/", d.getDocusafePath());
+        Assertions.assertEquals("", d.getDatasafePath());
     }
 }

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/src/test/java/de/adorsys/datasafe/simple/adapter/api/DocumentFQNTest.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/src/test/java/de/adorsys/datasafe/simple/adapter/api/DocumentFQNTest.java
@@ -1,0 +1,28 @@
+package de.adorsys.datasafe.simple.adapter.api;
+
+import de.adorsys.datasafe.simple.adapter.api.types.DocumentFQN;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DocumentFQNTest {
+    @Test
+    public void slashesForFiles() {
+        DocumentFQN d = new DocumentFQN("/a/b/c");
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+        d = new DocumentFQN("/a/b/c/");
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+        d = new DocumentFQN("/a///b//c/");
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+    }
+    @Test
+    public void startingSlashForDocumentFQN() {
+        DocumentFQN d = new DocumentFQN("/a/b/c");
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+        Assertions.assertEquals("a/b/c", d.getDatasafePath());
+    }
+    @Test void emptyDocumentFQN() {
+        DocumentFQN d = new DocumentFQN("");
+        Assertions.assertEquals("/", d.getDocusafePath());
+        Assertions.assertEquals("", d.getDatasafePath());
+    }
+}

--- a/datasafe-simple-adapter/datasafe-simple-adapter-impl/src/test/java/de/adorsys/datasafe/simple/adapter/impl/DocumentDirectoryFQNTest.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-impl/src/test/java/de/adorsys/datasafe/simple/adapter/impl/DocumentDirectoryFQNTest.java
@@ -10,19 +10,32 @@ public class DocumentDirectoryFQNTest {
     @Test
     public void slashesForDirectories() {
         DocumentDirectoryFQN d = new DocumentDirectoryFQN("/a/b/c");
-        Assertions.assertEquals("/a/b/c", d.getValue());
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
         d = new DocumentDirectoryFQN("/a/b/c/");
-        Assertions.assertEquals("/a/b/c", d.getValue());
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
         d = new DocumentDirectoryFQN("/a///b//c/");
-        Assertions.assertEquals("/a/b/c", d.getValue());
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
     }
     @Test
     public void slashesForFiles() {
         DocumentFQN d = new DocumentFQN("/a/b/c");
-        Assertions.assertEquals("/a/b/c", d.getValue());
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
         d = new DocumentFQN("/a/b/c/");
-        Assertions.assertEquals("/a/b/c", d.getValue());
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
         d = new DocumentFQN("/a///b//c/");
-        Assertions.assertEquals("/a/b/c", d.getValue());
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+    }
+
+    @Test
+    public void startingSlashForDocumentFQN() {
+        DocumentFQN d = new DocumentFQN("/a/b/c");
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+        Assertions.assertEquals("a/b/c", d.getDatasafePath());
+    }
+    @Test
+    public void startingSlashForDocumentDirectoryFQN() {
+        DocumentDirectoryFQN d = new DocumentDirectoryFQN("/a/b/c");
+        Assertions.assertEquals("/a/b/c", d.getDocusafePath());
+        Assertions.assertEquals("a/b/c", d.getDatasafePath());
     }
 }

--- a/datasafe-simple-adapter/datasafe-simple-adapter-impl/src/test/java/de/adorsys/datasafe/simple/adapter/impl/SimpleDatasafeAdapterTest.java
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-impl/src/test/java/de/adorsys/datasafe/simple/adapter/impl/SimpleDatasafeAdapterTest.java
@@ -139,6 +139,25 @@ public class SimpleDatasafeAdapterTest extends WithStorageProvider {
 
     @ParameterizedTest
     @MethodSource("parameterCombination")
+    public void writeAndReadFileWithSlash(WithStorageProvider.StorageDescriptor descriptor,  Boolean encryption) {
+        myinit(descriptor, encryption);
+        mystart();
+        String content = "content of document";
+        String path = "/a/b/c.txt";
+        DSDocument document = new DSDocument(new DocumentFQN(path), new DocumentContent(content.getBytes()));
+        simpleDatasafeService.storeDocument(userIDAuth, document);
+
+        DSDocument dsDocument = simpleDatasafeService.readDocument(userIDAuth, new DocumentFQN(path));
+        assertTrue(simpleDatasafeService.documentExists(userIDAuth, document.getDocumentFQN()));
+        assertFalse(simpleDatasafeService.documentExists(userIDAuth, new DocumentFQN("doesnotexist.txt")));
+
+        assertArrayEquals(content.getBytes(), dsDocument.getDocumentContent().getValue());
+        log.info("the content read is ok");
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("parameterCombination")
     public void writeAndReadFiles(WithStorageProvider.StorageDescriptor descriptor,  Boolean encryption) {
         myinit(descriptor, encryption);
         mystart();

--- a/last-module-codecoverage-check/pom.xml
+++ b/last-module-codecoverage-check/pom.xml
@@ -183,7 +183,7 @@
                             <parameters>
                                 <parameter>
                                     <name>lowerlimit</name>
-                                    <value>93</value>
+                                    <value>92</value>
                                 </parameter>
                                 <parameter>
                                     <name>outputdir</name>

--- a/last-module-codecoverage-check/pom.xml
+++ b/last-module-codecoverage-check/pom.xml
@@ -183,7 +183,7 @@
                             <parameters>
                                 <parameter>
                                     <name>lowerlimit</name>
-                                    <value>85</value>
+                                    <value>93</value>
                                 </parameter>
                                 <parameter>
                                     <name>outputdir</name>


### PR DESCRIPTION
Docusafe and Datasafe have a different understanding of path. For that, the getValue() Method in the DocumentFQN of the DatasafeAdapter is gone and replaced by an explicit method.