### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,3 +133,7 @@ matrix:
         - echo 'Nothing to do' # Override primary build logic
 
     # No WINDOWS here because it is in beta status yet.
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/datasafe-business/pom.xml
+++ b/datasafe-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-business/pom.xml
+++ b/datasafe-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-cli/pom.xml
+++ b/datasafe-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>datasafe-cli</artifactId>

--- a/datasafe-cli/pom.xml
+++ b/datasafe-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>datasafe-cli</artifactId>

--- a/datasafe-directory/datasafe-directory-api/pom.xml
+++ b/datasafe-directory/datasafe-directory-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>de.adorsys</groupId>
     <artifactId>datasafe-directory</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>datasafe-directory-api</artifactId>
 	<dependencies>

--- a/datasafe-directory/datasafe-directory-api/pom.xml
+++ b/datasafe-directory/datasafe-directory-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>de.adorsys</groupId>
     <artifactId>datasafe-directory</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
   </parent>
   <artifactId>datasafe-directory-api</artifactId>
 	<dependencies>

--- a/datasafe-directory/datasafe-directory-impl/pom.xml
+++ b/datasafe-directory/datasafe-directory-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>de.adorsys</groupId>
     <artifactId>datasafe-directory</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
   </parent>
   <artifactId>datasafe-directory-impl</artifactId>
 	<dependencies>

--- a/datasafe-directory/datasafe-directory-impl/pom.xml
+++ b/datasafe-directory/datasafe-directory-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>de.adorsys</groupId>
     <artifactId>datasafe-directory</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
   </parent>
   <artifactId>datasafe-directory-impl</artifactId>
 	<dependencies>

--- a/datasafe-directory/pom.xml
+++ b/datasafe-directory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-directory/pom.xml
+++ b/datasafe-directory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-encryption/datasafe-encryption-api/pom.xml
+++ b/datasafe-encryption/datasafe-encryption-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-encryption</artifactId>
-		<version>1.0.3</version>
+		<version>1.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>datasafe-encryption-api</artifactId>
 	<dependencies>

--- a/datasafe-encryption/datasafe-encryption-api/pom.xml
+++ b/datasafe-encryption/datasafe-encryption-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-encryption</artifactId>
-		<version>1.0.3-SNAPSHOT</version>
+		<version>1.0.3</version>
 	</parent>
 	<artifactId>datasafe-encryption-api</artifactId>
 	<dependencies>

--- a/datasafe-encryption/datasafe-encryption-impl/pom.xml
+++ b/datasafe-encryption/datasafe-encryption-impl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-encryption</artifactId>
-		<version>1.0.3</version>
+		<version>1.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>datasafe-encryption-impl</artifactId>
 	<dependencies>

--- a/datasafe-encryption/datasafe-encryption-impl/pom.xml
+++ b/datasafe-encryption/datasafe-encryption-impl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-encryption</artifactId>
-		<version>1.0.3-SNAPSHOT</version>
+		<version>1.0.3</version>
 	</parent>
 	<artifactId>datasafe-encryption-impl</artifactId>
 	<dependencies>

--- a/datasafe-encryption/pom.xml
+++ b/datasafe-encryption/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-encryption/pom.xml
+++ b/datasafe-encryption/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-examples/datasafe-examples-business/pom.xml
+++ b/datasafe-examples/datasafe-examples-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-examples-business</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-business/pom.xml
+++ b/datasafe-examples/datasafe-examples-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-examples-business</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-customize-dagger/pom.xml
+++ b/datasafe-examples/datasafe-examples-customize-dagger/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-examples-customize-dagger</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-customize-dagger/pom.xml
+++ b/datasafe-examples/datasafe-examples-customize-dagger/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-examples-customize-dagger</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-multidfs/pom.xml
+++ b/datasafe-examples/datasafe-examples-multidfs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-examples-multidfs</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-multidfs/pom.xml
+++ b/datasafe-examples/datasafe-examples-multidfs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-examples-multidfs</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-versioned-s3/pom.xml
+++ b/datasafe-examples/datasafe-examples-versioned-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-examples-versioned-s3</artifactId>
     <dependencies>

--- a/datasafe-examples/datasafe-examples-versioned-s3/pom.xml
+++ b/datasafe-examples/datasafe-examples-versioned-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-examples</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-examples-versioned-s3</artifactId>
     <dependencies>

--- a/datasafe-examples/pom.xml
+++ b/datasafe-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-examples/pom.xml
+++ b/datasafe-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-inbox/datasafe-inbox-api/pom.xml
+++ b/datasafe-inbox/datasafe-inbox-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-inbox</artifactId>
-		<version>1.0.3</version>
+		<version>1.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>datasafe-inbox-api</artifactId>
 	<dependencies>

--- a/datasafe-inbox/datasafe-inbox-api/pom.xml
+++ b/datasafe-inbox/datasafe-inbox-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-inbox</artifactId>
-		<version>1.0.3-SNAPSHOT</version>
+		<version>1.0.3</version>
 	</parent>
 	<artifactId>datasafe-inbox-api</artifactId>
 	<dependencies>

--- a/datasafe-inbox/datasafe-inbox-impl/pom.xml
+++ b/datasafe-inbox/datasafe-inbox-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-inbox</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-inbox-impl</artifactId>
     <dependencies>

--- a/datasafe-inbox/datasafe-inbox-impl/pom.xml
+++ b/datasafe-inbox/datasafe-inbox-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe-inbox</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-inbox-impl</artifactId>
     <dependencies>

--- a/datasafe-inbox/pom.xml
+++ b/datasafe-inbox/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-inbox/pom.xml
+++ b/datasafe-inbox/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-long-run-tests/datasafe-business-tests-random-actions/pom.xml
+++ b/datasafe-long-run-tests/datasafe-business-tests-random-actions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-long-run-tests</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-long-run-tests/datasafe-business-tests-random-actions/pom.xml
+++ b/datasafe-long-run-tests/datasafe-business-tests-random-actions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-long-run-tests</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-long-run-tests/pom.xml
+++ b/datasafe-long-run-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-long-run-tests/pom.xml
+++ b/datasafe-long-run-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-metainfo/datasafe-metainfo-version-api/pom.xml
+++ b/datasafe-metainfo/datasafe-metainfo-version-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-metainfo</artifactId>
-		<version>1.0.3</version>
+		<version>1.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>datasafe-metainfo-version-api</artifactId>
 	<dependencies>

--- a/datasafe-metainfo/datasafe-metainfo-version-api/pom.xml
+++ b/datasafe-metainfo/datasafe-metainfo-version-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-metainfo</artifactId>
-		<version>1.0.3-SNAPSHOT</version>
+		<version>1.0.3</version>
 	</parent>
 	<artifactId>datasafe-metainfo-version-api</artifactId>
 	<dependencies>

--- a/datasafe-metainfo/datasafe-metainfo-version-impl/pom.xml
+++ b/datasafe-metainfo/datasafe-metainfo-version-impl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-metainfo</artifactId>
-		<version>1.0.3</version>
+		<version>1.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>datasafe-metainfo-version-impl</artifactId>
 	<dependencies>

--- a/datasafe-metainfo/datasafe-metainfo-version-impl/pom.xml
+++ b/datasafe-metainfo/datasafe-metainfo-version-impl/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-metainfo</artifactId>
-		<version>1.0.3-SNAPSHOT</version>
+		<version>1.0.3</version>
 	</parent>
 	<artifactId>datasafe-metainfo-version-impl</artifactId>
 	<dependencies>

--- a/datasafe-metainfo/pom.xml
+++ b/datasafe-metainfo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-metainfo/pom.xml
+++ b/datasafe-metainfo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-privatestore/datasafe-privatestore-api/pom.xml
+++ b/datasafe-privatestore/datasafe-privatestore-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-privatestore</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-privatestore/datasafe-privatestore-api/pom.xml
+++ b/datasafe-privatestore/datasafe-privatestore-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-privatestore</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-privatestore/datasafe-privatestore-impl/pom.xml
+++ b/datasafe-privatestore/datasafe-privatestore-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-privatestore</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-privatestore/datasafe-privatestore-impl/pom.xml
+++ b/datasafe-privatestore/datasafe-privatestore-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-privatestore</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-privatestore/pom.xml
+++ b/datasafe-privatestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-privatestore/pom.xml
+++ b/datasafe-privatestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-rest-impl/pom.xml
+++ b/datasafe-rest-impl/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>datasafe-rest-impl</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
     <name>datasafe-rest-impl</name>
     <description>Spring Boot DataSafe Application</description>
 

--- a/datasafe-rest-impl/pom.xml
+++ b/datasafe-rest-impl/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>datasafe-rest-impl</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>datasafe-rest-impl</name>
     <description>Spring Boot DataSafe Application</description>
 

--- a/datasafe-runtime-delegate/pom.xml
+++ b/datasafe-runtime-delegate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-runtime-delegate</artifactId>
     <dependencies>

--- a/datasafe-runtime-delegate/pom.xml
+++ b/datasafe-runtime-delegate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-runtime-delegate</artifactId>
     <dependencies>

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-simple-adapter</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/datasafe-simple-adapter-api/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-simple-adapter</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/datasafe-simple-adapter-impl/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-simple-adapter</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/datasafe-simple-adapter-impl/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-simple-adapter</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/datasafe-simple-adapter-spring/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-simple-adapter</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/datasafe-simple-adapter-spring/pom.xml
+++ b/datasafe-simple-adapter/datasafe-simple-adapter-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-simple-adapter</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/pom.xml
+++ b/datasafe-simple-adapter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-simple-adapter/pom.xml
+++ b/datasafe-simple-adapter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/datasafe-storage-api/pom.xml
+++ b/datasafe-storage/datasafe-storage-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-storage</artifactId>
-		<version>1.0.3</version>
+		<version>1.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>datasafe-storage-api</artifactId>
 	<dependencies>

--- a/datasafe-storage/datasafe-storage-api/pom.xml
+++ b/datasafe-storage/datasafe-storage-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.adorsys</groupId>
 		<artifactId>datasafe-storage</artifactId>
-		<version>1.0.3-SNAPSHOT</version>
+		<version>1.0.3</version>
 	</parent>
 	<artifactId>datasafe-storage-api</artifactId>
 	<dependencies>

--- a/datasafe-storage/datasafe-storage-impl-db/pom.xml
+++ b/datasafe-storage/datasafe-storage-impl-db/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-storage</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/datasafe-storage-impl-db/pom.xml
+++ b/datasafe-storage/datasafe-storage-impl-db/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-storage</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/datasafe-storage-impl-fs/pom.xml
+++ b/datasafe-storage/datasafe-storage-impl-fs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-storage</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/datasafe-storage-impl-fs/pom.xml
+++ b/datasafe-storage/datasafe-storage-impl-fs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-storage</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/datasafe-storage-impl-s3/pom.xml
+++ b/datasafe-storage/datasafe-storage-impl-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-storage</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/datasafe-storage-impl-s3/pom.xml
+++ b/datasafe-storage/datasafe-storage-impl-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe-storage</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/pom.xml
+++ b/datasafe-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-storage/pom.xml
+++ b/datasafe-storage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-test-storages/pom.xml
+++ b/datasafe-test-storages/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-test-storages/pom.xml
+++ b/datasafe-test-storages/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/datasafe-types-api/pom.xml
+++ b/datasafe-types-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>datasafe-types-api</artifactId>
     <dependencies>

--- a/datasafe-types-api/pom.xml
+++ b/datasafe-types-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.adorsys</groupId>
         <artifactId>datasafe</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>datasafe-types-api</artifactId>
     <dependencies>

--- a/last-module-codecoverage-check/pom.xml
+++ b/last-module-codecoverage-check/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/last-module-codecoverage-check/pom.xml
+++ b/last-module-codecoverage-check/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>datasafe</artifactId>
         <groupId>de.adorsys</groupId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>de.adorsys</groupId>
     <artifactId>datasafe</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
     <name>datasafe</name>
     <description>Datasafe</description>
     <url>https://github.com/adorsys/datasafe</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>de.adorsys</groupId>
     <artifactId>datasafe</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>datasafe</name>
     <description>Datasafe</description>
     <url>https://github.com/adorsys/datasafe</url>


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.