### PR TITLE
Fix: ensure unique iv generation for GCM encryption to prevent reuse error

### DIFF
--- a/datasafe-encryption/datasafe-encryption-impl/src/main/java/de/adorsys/datasafe/encrypiton/impl/cmsencryption/CMSEncryptionServiceImpl.java
+++ b/datasafe-encryption/datasafe-encryption-impl/src/main/java/de/adorsys/datasafe/encrypiton/impl/cmsencryption/CMSEncryptionServiceImpl.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.Key;
 import java.security.KeyPair;
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -145,7 +146,7 @@ public class CMSEncryptionServiceImpl implements CMSEncryptionService {
 
         return generator.open(
                 dataContentStream,
-                new JceCMSContentEncryptorBuilder(algorithm).setProvider(GeneratorModule_ProviderFactory.provider()).build()
+                new JceCMSContentEncryptorBuilder(algorithm).setProvider(GeneratorModule_ProviderFactory.provider()).setSecureRandom(new SecureRandom()).build()
         );
     }
 }

--- a/datasafe-encryption/datasafe-encryption-impl/src/main/java/de/adorsys/datasafe/encrypiton/impl/cmsencryption/CMSEncryptionServiceImpl.java
+++ b/datasafe-encryption/datasafe-encryption-impl/src/main/java/de/adorsys/datasafe/encrypiton/impl/cmsencryption/CMSEncryptionServiceImpl.java
@@ -48,10 +48,12 @@ import java.util.stream.Collectors;
 public class CMSEncryptionServiceImpl implements CMSEncryptionService {
 
     private ASNCmsEncryptionConfig encryptionConfig;
+    private SecureRandom secureRandom;
 
     @Inject
     public CMSEncryptionServiceImpl(ASNCmsEncryptionConfig encryptionConfig) {
         this.encryptionConfig = encryptionConfig;
+        this.secureRandom = new SecureRandom();
     }
 
     /**
@@ -146,7 +148,7 @@ public class CMSEncryptionServiceImpl implements CMSEncryptionService {
 
         return generator.open(
                 dataContentStream,
-                new JceCMSContentEncryptorBuilder(algorithm).setProvider(GeneratorModule_ProviderFactory.provider()).setSecureRandom(new SecureRandom()).build()
+                new JceCMSContentEncryptorBuilder(algorithm).setProvider(GeneratorModule_ProviderFactory.provider()).setSecureRandom( this.secureRandom).build()
         );
     }
 }


### PR DESCRIPTION
Added `SecureRandom` to JceCMSContentEncryptorBuilder in CMSEncryptionServiceImpl to ensure unique IV generation for each encryption operation.
