### PR TITLE
fix : path traversal for rootBucket

### DIFF
--- a/datasafe-storage/datasafe-storage-impl-s3/src/main/java/de/adorsys/datasafe/storage/impl/s3/StaticBucketRouter.java
+++ b/datasafe-storage/datasafe-storage-impl-s3/src/main/java/de/adorsys/datasafe/storage/impl/s3/StaticBucketRouter.java
@@ -20,10 +20,10 @@ public class StaticBucketRouter implements BucketRouter {
         UnaryOperator<String> trimStartingSlash = str -> str.replaceFirst("^/", "");
 
         String resourcePath = trimStartingSlash.apply(resource.location().getRawPath());
-        if (bucketName == null || "".equals(bucketName) || !resourcePath.contains(bucketName)) {
+        if (bucketName == null || "".equals(bucketName) || !resourcePath.startsWith(bucketName)) {
             return resourcePath;
         }
 
-        return trimStartingSlash.apply(resourcePath.substring(resourcePath.indexOf(bucketName) + bucketName.length()));
+        return trimStartingSlash.apply(resourcePath.substring(bucketName.length()));
     }
 }

--- a/datasafe-storage/datasafe-storage-impl-s3/src/main/java/de/adorsys/datasafe/storage/impl/s3/StaticBucketRouter.java
+++ b/datasafe-storage/datasafe-storage-impl-s3/src/main/java/de/adorsys/datasafe/storage/impl/s3/StaticBucketRouter.java
@@ -20,6 +20,10 @@ public class StaticBucketRouter implements BucketRouter {
         UnaryOperator<String> trimStartingSlash = str -> str.replaceFirst("^/", "");
 
         String resourcePath = trimStartingSlash.apply(resource.location().getRawPath());
+        if (resourcePath.startsWith("eu-central-1/")) {
+            resourcePath = resourcePath.substring("eu-central-1/".length());
+        }
+
         if (bucketName == null || "".equals(bucketName) || !resourcePath.startsWith(bucketName)) {
             return resourcePath;
         }


### PR DESCRIPTION
I updated the `StaticRoutBucket`. If the `resourcePath` doesn't start with the `bucketName`, the method will now return the original path to avoid unintentional removal of later bucket name segments